### PR TITLE
Optimized mse, ce, sum softmax and transpose function with vectorization

### DIFF
--- a/dv/operators/forward.mojo
+++ b/dv/operators/forward.mojo
@@ -168,9 +168,12 @@ fn relu(inout b: Tensor, a: Tensor):
 @always_inline
 fn sum(inout b: Tensor, a: Tensor):
     var sum: Float32 = 0
-    for i in range(a.cap):
-        sum += a.data.load(i)
-    b.set_data(0,sum)
+
+    @parameter
+    fn v_sum[nelts: Int](i: Int):
+        sum += a.data.simd_load[nelts](i).reduce_add()
+
+    b.set_data(0, sum)
 
 @always_inline
 fn softmax(inout b: Tensor, a: Tensor):


### PR DESCRIPTION
**Extra**: A problem i have seen in the matmul operator, is that it seems that parallelize is very slow since the removal of the runtime, now it doesn't use all threads in the cpu, it only uses the cores. And using parallelize is slower than not using it, in the example of regression task, if you remove parallelize for a simple for, in my computer i get 3 ms of speed instead of the 300 ms i get with parallelization, **so it seems that modular has to fix parallelization**.